### PR TITLE
Fix Shellcheck and use "$@" vs $* for argument-passing

### DIFF
--- a/run_bamstrap
+++ b/run_bamstrap
@@ -7,7 +7,7 @@ if [ -z "$USER" ]; then
   exit 1;
 fi
 
-if [ $(id -u) = 0 ]; then
+if [ "$(id -u)" = 0 ]; then
   echo "Aborting! Must not be run as root"
   exit 2
 fi
@@ -20,7 +20,7 @@ fi
 if ! command -v ruby >/dev/null || \
    (command -v ruby >/dev/null && ruby -e 'exit RUBY_VERSION.split(".").first(2).join(".").to_f < 2.3'); then
   echo "No suitable Ruby found (installing vendor Ruby)"
-  eval "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install-ruby`"
+  eval "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install-ruby)"
 fi
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -36,11 +36,11 @@ run_curl() {
   FILE_PATH="bambrew/lib/bambrew/bamstrap.rb"
   URL="https://api.github.com/repos/$ORGANISATION/$REPO/contents/$FILE_PATH"
 
-  curl $* --header "Authorization: token $GITHUB_TOKEN" \
+  curl "$@" --header "Authorization: token $GITHUB_TOKEN" \
        --header "Accept: application/vnd.github.v3.raw" \
        --silent \
        --show-error \
-       --location $URL
+       --location "$URL"
 }
 
 code=$(run_curl -o /dev/null -w "%{http_code}")


### PR DESCRIPTION
As per my upcoming blogpost, when passing arguments we want to be using "$@" not `$*`. Also, while I'm here, fixup the remaining Shellcheck issues