### PR TITLE
FB-8882: Fix exit codes for bambrew scripts

### DIFF
--- a/install_homebrew.sh
+++ b/install_homebrew.sh
@@ -23,13 +23,13 @@ if [ -z ${USER+ignored} ]; then
   # variable to be set, so just check upfront
   # https://github.com/Linuxbrew/install/issues/48
   # https://github.com/Linuxbrew/install/pull/49
-  abort_install "No USER environment variable set" 1
+  abort_install "No USER environment variable set" 3
 fi
 
 echo "USER is $USER"
 
 if [ $(id -u) = 0 ]; then
-  abort_install "Must not be run as root" 2
+  abort_install "Must not be run as root" 4
 fi
 
 if command -v brew >/dev/null 2>&1; then
@@ -41,7 +41,7 @@ required_packages="curl git"
 
 for package in $required_packages; do
   if ! command -v $package >/dev/null 2>&1; then
-    abort_install "No $package found - install using your package manager of choice" 3
+    abort_install "No $package found - install using your package manager of choice" 5
   fi
 done
 
@@ -54,6 +54,6 @@ case $(uname) in
     /usr/bin/ruby -e "$(curl_wrapper https://raw.githubusercontent.com/Homebrew/install/master/install)"
     ;;
   *)
-    abort_install "Unsupported platform '$(uname)'" 4
+    abort_install "Unsupported platform '$(uname)'" 6
     ;;
 esac

--- a/run_bamstrap
+++ b/run_bamstrap
@@ -4,17 +4,17 @@ set -e
 
 if [ -z "$USER" ]; then
   echo "Aborting! No USER environment variable set"
-  exit 1;
+  exit 3;
 fi
 
 if [ "$(id -u)" = 0 ]; then
   echo "Aborting! Must not be run as root"
-  exit 2
+  exit 4
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "Aborting! No curl found (install and retry)"
-  exit 3
+  exit 5
 fi
 
 if ! command -v ruby >/dev/null || \
@@ -27,7 +27,7 @@ if [ -z "$GITHUB_TOKEN" ]; then
   echo "Aborting! No GITHUB_TOKEN provided"
   echo "1. Follow these instructions to generate a personal access token: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
   echo "2. Provide this token in the GITHUB_TOKEN environment variable when running this script"
-  exit 4
+  exit 6
 fi
 
 run_curl() {
@@ -46,7 +46,7 @@ run_curl() {
 code=$(run_curl -o /dev/null -w "%{http_code}")
 if [ "$code" != "200" ]; then
   echo "Unexpected response code $code"
-  exit 5
+  exit 7
 fi
 
 ruby -e "$(run_curl)"


### PR DESCRIPTION
We are not currently using the exit codes for anything specific (other than that
they are non-zero for errors) but I happened to read [this][1] and learn that
certain exit codes (eg 2) are reserved for specific purposes.

[1]: https://www.tldp.org/LDP/abs/html/exitcodes.html

JIRA: [FB-8882](https://firstbanco.atlassian.net/browse/FB-8882)