### PR TITLE
FB-9901: Tweak install_homebrew.sh to also install Linux pre-requisites and Ruby for bamstrap

### DIFF
--- a/install_homebrew.sh
+++ b/install_homebrew.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-# A simple Homebrew installation wrapper, to hide the platform-specific stanzas:
+# A simple Homebrew installation wrapper, to install any platform-specific prerequisites, before
+# installing Homebrew.
 # macOS: https://brew.sh/
 # Linux: https://docs.brew.sh/Homebrew-on-Linux#install
 
@@ -11,8 +12,22 @@ abort_install() {
   exit $2
 }
 
-curl_wrapper() {
-  curl --fail --silent --show-error --location $1
+install_homebrew() {
+  echo "Installing Homebrew"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+}
+
+# On macOS, the Homebrew executable (brew) is installed to /usr/local/bin, which is in the PATH
+# by default on macOS (https://scriptingosx.com/2017/05/where-paths-come-from/). This means that on
+# macOS, as long as Homebrew is installed, no further setup is necessary in order to use it.
+# On Linux, Homebrew is installed to /home/linuxbrew/.linuxbrew using sudo if possible, and to
+# ~/.linuxbrew otherwise (ie if sudo is not available). For this reason, the recommended approach
+# (https://docs.brew.sh/Homebrew-on-Linux#install) is to check both possible install locations and
+# call the `brew shellenv` command if found, to export the required env vars into the shell. This
+# includes adding the right installation directory to the PATH so brew can be invoked.
+initialise_homebrew_on_linux() {
+  test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
+  test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
 # Note: if $USER is not set, a normal `-z "$USER"` check would error as we have
@@ -26,34 +41,38 @@ if [ -z ${USER+ignored} ]; then
   abort_install "No USER environment variable set" 3
 fi
 
-echo "USER is $USER"
-
 if [ $(id -u) = 0 ]; then
   abort_install "Must not be run as root" 4
 fi
+
+initialise_homebrew_on_linux || true
 
 if command -v brew >/dev/null 2>&1; then
   echo "Homebrew already installed 👍"
   exit
 fi
 
-required_packages="curl git"
-
-for package in $required_packages; do
-  if ! command -v $package >/dev/null 2>&1; then
-    abort_install "No $package found - install using your package manager of choice" 5
-  fi
-done
-
-echo "Installing Homebrew"
 case $(uname) in
   Linux)
-    sh -c "$(curl_wrapper https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+    if ! command -v apt-get >/dev/null 2>&1; then
+      abort_install "Unsupported Linux package manager (no apt-get found)" 6
+    fi
+    echo "Installing prerequisites for $(uname)"
+    sudo apt-get update -y && sudo apt-get install -y build-essential curl file git
+    install_homebrew
+    initialise_homebrew_on_linux || true
+    # As per the Homebrew post installation message:
+    # - We recommend that you install GCC by running:
+    #     brew install gcc
+    brew install gcc
     ;;
   Darwin)
-    /usr/bin/ruby -e "$(curl_wrapper https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    install_homebrew
     ;;
   *)
-    abort_install "Unsupported platform '$(uname)'" 6
+    abort_install "Unsupported platform '$(uname)'" 7
     ;;
 esac
+
+# Install ruby as it's required to run bamstrap, which bootstraps Bambrew
+brew install ruby


### PR DESCRIPTION
Small tweak to the `install_homebrew.sh` script to automatically install the Linux pre-requisites
for Homebrew, as documented [here][1]. Also, because bamstrap requires Ruby, which isn't available
by default on Linux, or macOS since [10.15 (Catalina)][2], we install that using `brew` as well.

[1]: https://docs.brew.sh/Homebrew-on-Linux
[2]: https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes

JIRA: [FB-9901](https://firstbanco.atlassian.net/browse/FB-9901)