### PR TITLE
FB-14542: Update bamstrap to request Github tokens during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bambrew - Bamboo Engineering's development environment setup tooling
 1. Run the following at a command prompt:
 
 ```
-$ GITHUB_TOKEN="your access token" sh -c "$(curl -fsSL https://github.com/bambooengineering/bambrew/raw/master/run_bamstrap)"
+sh -c "$(curl -fsSL https://github.com/bambooengineering/bambrew/raw/master/run_bamstrap)"
 ```
 
 [1]: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line

--- a/run_bamstrap
+++ b/run_bamstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -24,10 +24,8 @@ if ! command -v ruby >/dev/null || \
 fi
 
 if [ -z "$GITHUB_TOKEN" ]; then
-  echo "Aborting! No GITHUB_TOKEN provided"
-  echo "1. Follow these instructions to generate a personal access token: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
-  echo "2. Provide this token in the GITHUB_TOKEN environment variable when running this script"
-  exit 6
+  echo "Please provide your Github Token (you can generate one at https://github.com/settings/tokens):"
+  read -s GITHUB_TOKEN
 fi
 
 run_curl() {


### PR DESCRIPTION
JIRA: [FB-14542](https://firstbanco.atlassian.net/browse/FB-14542)

Removing the need to paste the GitHub token visibly, for security reasons, as per (https://github.com/bambooengineering/umbrella/pull/17436#issuecomment-1232858175)